### PR TITLE
Dynamic cli options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,4 @@ jobs:
 
     - name: Publishing documentation
       run: |
-        ghp-import -n -c humanmark.tkte.ch -p docs/build/html
+        ghp-import -f -n -c humanmark.tkte.ch -p docs/build/html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, Tyler Kennedy'
 author = 'Tyler Kennedy'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.1'
+release = '0.3.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/humanmark/cli.py
+++ b/humanmark/cli.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 try:
     import click
 except ImportError:
@@ -8,8 +10,44 @@ except ImportError:
     )
 
 from humanmark import loads, dumps
-from humanmark.render import available_renderers
+from humanmark.render import Renderer, available_renderers
 from humanmark.backends import available_backends
+
+
+def dynamic_command(expand_renderer=False, expand_backend=False):
+    class DynamicCommand(click.Command):
+        """A special ``click.Command`` subclass that generates
+        ``click.Options`` for the selected renderer and backend."""
+        def get_params(self, ctx):
+            # get_params is undocumented, but I can't see a better way of
+            # doing this. A decorator doesn't have access to the context, so
+            # we don't know what renderer/backend to use. `make_parser` is
+            # documented, but isn't even used by the --help command!
+            params = super().get_params(ctx)
+            renderer: Renderer = ctx.obj.get('renderer')
+            if expand_renderer and renderer:
+                # A renderer was specified, so we want to parse out its options
+                # dataclass and turn them into options.
+                options = renderer.OPTIONS_CLASS
+                fields = dataclasses.fields(options)
+                for field in fields:
+                    safe_field_name = field.name.replace('_', '-')
+                    param_name = f'--r-{safe_field_name}'
+                    if field.type is bool:
+                        param_name = f'{param_name}/--no-r-{safe_field_name}'
+
+                    params.append(
+                        click.Option(
+                            [param_name],
+                            is_flag=field.type is bool,
+                            type=field.type,
+                            default=field.default,
+                            help=f'Default is [{field.default!r}]'
+                        )
+                    )
+
+            return params
+    return DynamicCommand
 
 
 @click.group()
@@ -33,13 +71,13 @@ def cli(ctx, backend, renderer):
     ctx.obj['renderer'] = available_renderers()[renderer]
 
 
-@cli.command('render')
+@cli.command('render', cls=dynamic_command(expand_renderer=True))
 @click.argument('source', type=click.File('rt'))
-@click.pass_context
-def render_command(ctx, source):
+@click.pass_obj
+def render_command(obj, source, **kwargs):
     """Parse and render `source`."""
-    backend = ctx.obj['backend']()
-    renderer = ctx.obj['renderer']()
+    backend = obj['backend']()
+    renderer = obj['renderer']()
 
     fragment = loads(source.read(), backend=backend)
     click.echo(dumps(fragment, renderer=renderer))
@@ -47,11 +85,11 @@ def render_command(ctx, source):
 
 @cli.command('tree')
 @click.argument('source', type=click.File('rt'))
-@click.pass_context
-def tree(ctx, source):
+@click.pass_obj
+def tree(obj, source):
     """Pretty-print a visual representation of a parsed markdown file's
     AST (abstract syntax tree)."""
-    backend = ctx.obj['backend']()
+    backend = obj['backend']()
     fragment = loads(source.read(), backend=backend)
     click.echo(fragment.pretty())
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.3.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(root, 'README.md'), 'rb') as readme:
 setup(
     name='humanmark',
     packages=find_packages(),
-    version='0.3.1',
+    version='0.3.2',
     description='Human-friendly markdown.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
An attempt at dynamically generating the command line flags for renderers and backends based off of which one the user has selected before running --help.